### PR TITLE
Enhance library with SwiftUI support

### DIFF
--- a/CallingCodesKit.podspec
+++ b/CallingCodesKit.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'CallingCodesKit'
-  s.version          = '0.1.1'
+  s.version          = '0.1.2'
   s.summary          = 'Countries Calling Codes Name Flags and Country Codes.'
   
   # This description is used to generate tags and improve search results.

--- a/CallingCodesKit/Classes/CallingCodesListView.swift
+++ b/CallingCodesKit/Classes/CallingCodesListView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+@available(iOS 15.0, *)
+public struct CallingCodesListView: View {
+    private let onSelect: (CountryCallingCode_Data) -> Void
+    @State private var countries: [CountryCallingCode_Data] = []
+    @State private var searchText: String = ""
+
+    public init(onSelect: @escaping (CountryCallingCode_Data) -> Void) {
+        self.onSelect = onSelect
+    }
+
+    public var body: some View {
+        List(filteredCountries) { country in
+            Button(action: {
+                onSelect(country)
+            }) {
+                HStack {
+                    Text(country.flag ?? "")
+                    Text(country.name ?? "")
+                    Spacer()
+                    Text(country.dialCode ?? "")
+                }
+            }
+        }
+        .searchable(text: $searchText)
+        .onAppear(perform: loadData)
+        .navigationBarTitle("Countries", displayMode: .inline)
+    }
+
+    private var filteredCountries: [CountryCallingCode_Data] {
+        if searchText.isEmpty { return countries }
+        return countries.filter { country in
+            (country.name?.lowercased().contains(searchText.lowercased()) ?? false) ||
+            (country.dialCode?.lowercased().contains(searchText.lowercased()) ?? false)
+        }
+    }
+
+    private func loadData() {
+        ContryJsonData.loadData { model in
+            countries = model.countries ?? []
+        }
+    }
+}

--- a/CallingCodesKit/Classes/CallingCodesVC.swift
+++ b/CallingCodesKit/Classes/CallingCodesVC.swift
@@ -126,27 +126,38 @@ extension CallingCodesVC  : UITableViewDelegate,UITableViewDataSource{
 
 open class ContryJsonData{
     static func loadData(compltionalHandler : @escaping(CountryCallingCodeModel)->()) {
+        var bundles: [Bundle] = []
+
+        #if SWIFT_PACKAGE
+        bundles.append(Bundle.module)
+        #endif
+
         let myBundle = Bundle(for: Self.self)
+        bundles.append(myBundle)
 
-        // Resources are packaged inside a separate bundle when distributed via
-        // CocoaPods. Look for that bundle first and then the JSON file inside it.
-        guard
-            let bundleURL = myBundle.url(forResource: "CallingCodesKit", withExtension: "bundle"),
-            let resourceBundle = Bundle(url: bundleURL),
-            let jsonURL = resourceBundle.url(forResource: "CountryCallingCode", withExtension: "json")
-        else {
-            return
+        if let bundleURL = myBundle.url(forResource: "CallingCodesKit", withExtension: "bundle"),
+           let resourceBundle = Bundle(url: bundleURL) {
+            bundles.append(resourceBundle)
         }
 
-        do {
-            let data = try Data(contentsOf: jsonURL)
-            let callingCodes = try JSONDecoder().decode(CountryCallingCodeModel.self, from: data)
-            compltionalHandler(callingCodes)
-        } catch {
-            // In case of failure return an empty model to avoid crashing.
-            print("Failed to load CountryCallingCode.json: \(error)")
-            compltionalHandler(CountryCallingCodeModel(countries: []))
+        bundles.append(Bundle.main)
+
+        for bundle in bundles {
+            if let jsonURL = bundle.url(forResource: "CountryCallingCode", withExtension: "json") {
+                do {
+                    let data = try Data(contentsOf: jsonURL)
+                    let callingCodes = try JSONDecoder().decode(CountryCallingCodeModel.self, from: data)
+                    compltionalHandler(callingCodes)
+                    return
+                } catch {
+                    continue
+                }
+            }
         }
+
+        // In case of failure return an empty model to avoid crashing.
+        print("Failed to load CountryCallingCode.json")
+        compltionalHandler(CountryCallingCodeModel(countries: []))
     }
 }
 
@@ -163,5 +174,9 @@ public struct CountryCallingCode_Data: Codable {
         case name, flag, code
         case dialCode = "dial_code"
     }
+}
+
+extension CountryCallingCode_Data: Identifiable {
+    public var id: String { code ?? UUID().uuidString }
 }
 

--- a/README.md
+++ b/README.md
@@ -7,20 +7,8 @@
 
 ## Example
 
-To run the example project, clone the repo, and run `pod install` from the Example directory first.
+To run the example project, clone the repo, and run `pod install` from the Example directory first. The country code data is bundled with the framework so no additional setup is required.
 
-## Requirements
-```
-1-Go to Pods
-2-Select Target CallingCodesKit
-3-Click on build Phase
-4-Click on Copy Bundel Resources
-5-click on + Button
-6- In CallingCodesKit Section You can find out Resources folder
-7- Select CountryCallingCode.json
-8-click add
-for more Details please See the video in Usage Section
-```
 ## Installation
 
 CallingCodesKit is available through [CocoaPods](https://cocoapods.org). To install
@@ -37,7 +25,7 @@ pod 'CallingCodesKit'
 
 ```
 import CallingCodesKit
- 
+
 class ViewController: UIViewController, callingCodeData
    
   {
@@ -56,6 +44,33 @@ class ViewController: UIViewController, callingCodeData
         textLabel.addGestureRecognizer(tap)    
     }
  }
+```
+
+### SwiftUI
+
+```swift
+import SwiftUI
+import CallingCodesKit
+
+struct ContentView: View {
+    @State private var selected: CountryCallingCode_Data?
+
+    var body: some View {
+        NavigationView {
+            VStack {
+                if let value = selected {
+                    Text("\(value.flag ?? "") \(value.name ?? "") \(value.dialCode ?? "")")
+                }
+                NavigationLink("Select Country") {
+                    CallingCodesListView { country in
+                        selected = country
+                    }
+                }
+            }
+            .navigationTitle("Example")
+        }
+    }
+}
 ```
 
 


### PR DESCRIPTION
## Summary
- load bundled JSON from any supported bundle
- mark models Identifiable and provide a `CallingCodesListView` for SwiftUI
- document SwiftUI usage and auto resource bundling
- bump podspec version to 0.1.2

## Testing
- `pod lib lint --allow-root`
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_688230a9431c8332a15454c8176774c2